### PR TITLE
Apply custom setup route

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "messages": "1.x"
   },
   "billingOptions": {
-    "free": true
+    "free": true,
+    "setupRoute": "/admin/app/gateway/payments/gocommerce.paghiper-app"
   },
   "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/messages/context.json
+++ b/messages/context.json
@@ -1,6 +1,6 @@
 {
-  "admin.payment.paghiper.additionalData.description": "",
-  "admin.payment.paghiper.boxGeneral": "General",
-  "admin.payment.paghiper.boxApplicationSetup": "Application Setup",
-  "admin.payment.paghiper.bankInvoiceActive": "Active bank invoice?"
+  "admin/payment.paghiper.additionalData.description": "",
+  "admin/payment.paghiper.boxGeneral": "General",
+  "admin/payment.paghiper.boxApplicationSetup": "Application Setup",
+  "admin/payment.paghiper.bankInvoiceActive": "Active bank invoice?"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,6 +1,6 @@
 {
-  "admin.payment.paghiper.additionalData.description": "",
-  "admin.payment.paghiper.boxGeneral": "General",
-  "admin.payment.paghiper.boxApplicationSetup": "Application Setup",
-  "admin.payment.paghiper.bankInvoiceActive": "Active bank invoice?"
+  "admin/payment.paghiper.additionalData.description": "",
+  "admin/payment.paghiper.boxGeneral": "General",
+  "admin/payment.paghiper.boxApplicationSetup": "Application Setup",
+  "admin/payment.paghiper.bankInvoiceActive": "Active bank invoice?"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,6 +1,6 @@
 {
-  "admin.payment.paghiper.additionalData.description": "",
-  "admin.payment.paghiper.boxGeneral": "General",
-  "admin.payment.paghiper.boxApplicationSetup": "Configuración de la aplicación",
-  "admin.payment.paghiper.bankInvoiceActive": "Boleto bancario activo"
+  "admin/payment.paghiper.additionalData.description": "",
+  "admin/payment.paghiper.boxGeneral": "General",
+  "admin/payment.paghiper.boxApplicationSetup": "Configuración de la aplicación",
+  "admin/payment.paghiper.bankInvoiceActive": "Boleto bancario activo"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,6 +1,6 @@
 {
-  "admin.payment.paghiper.additionalData.description": "",
-  "admin.payment.paghiper.boxGeneral": "Geral",
-  "admin.payment.paghiper.boxApplicationSetup": "Configuração do aplicativo",
-  "admin.payment.paghiper.bankInvoiceActive": "Boleto bancário ativo"
+  "admin/payment.paghiper.additionalData.description": "",
+  "admin/payment.paghiper.boxGeneral": "Geral",
+  "admin/payment.paghiper.boxApplicationSetup": "Configuração do aplicativo",
+  "admin/payment.paghiper.bankInvoiceActive": "Boleto bancário ativo"
 }

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -22,7 +22,7 @@ class PaymentFormComponent extends React.PureComponent<PaymentFormProps, Payment
         {({ accountData }:AccountDataInterface) => {
           const { country } = accountData
           const { intl } = this.props
-          const intlPrefix = 'admin.payment.paghiper'
+          const intlPrefix = 'admin/payment.paghiper'
           const paymentSchema = {
             "title": "PagHiper",
             "properties": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is how the new my apps section on admin will know if an app has a custom setup page. It doesn;t conflict with current apps app.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
We must provide a way to access the app's advanced setup page.
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
This page must have a button to access the app's advanced setup page https://augusto--mystore.mygocommerce.com/admin/apps/gocommerce.paghiper-app@2.0.1/setup/

#### Screenshots or example usage

#### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
